### PR TITLE
Remove 1.0.2 Limitation

### DIFF
--- a/spree_redirects.gemspec
+++ b/spree_redirects.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency('spree_core', '~> 1.0.0', '< 1.0.2')
+  s.add_runtime_dependency('spree_core', '~> 1.0.0')
   
   s.add_development_dependency('dummier',      '~> 0.3.0')
   s.add_development_dependency('shoulda',      '~> 3.0.0')


### PR DESCRIPTION
I'm pretty sure that Spree is using semantic versioning (http://semver.org/). I wouldn't think that a minor 1.0.x release would break an extension. 

Could we remove the 1.0.1-only limitation?
