### PR TITLE
Fix for Rails 3.2 Production

### DIFF
--- a/app/models/spree/redirect.rb
+++ b/app/models/spree/redirect.rb
@@ -19,7 +19,7 @@ class Spree::Redirect < ActiveRecord::Base
     end
     
     def normalize_url(url)
-      return url if url.blank?
+      return url if url.blank? or url == '/'
       url.strip.sub(/^[\/\s]*/, "/").sub(/\/+$/, "")
     end
 

--- a/lib/spree_redirects/engine.rb
+++ b/lib/spree_redirects/engine.rb
@@ -1,25 +1,11 @@
 module SpreeRedirects
   class Engine < Rails::Engine
-    
     engine_name "spree_redirects"
     
     initializer "redirect middleware" do |app|
-      app.middleware.insert_after ::ActionDispatch::ShowExceptions, ::SpreeRedirects::RedirectMiddleware
+      app.middleware.insert_after ::ActionDispatch::DebugExceptions, ::SpreeRedirects::RedirectMiddleware
     end
 
-    config.to_prepare do
-      
-      # We're not using any decorators so there's no need for this
-      
-      # Dir.glob File.expand_path("../../../app/**/*_decorator.rb", __FILE__) do |c|
-      #   Rails.configuration.cache_classes ? require(c) : load(c)
-      # end
-
-      Dir.glob File.expand_path("../../../app/overrides/**/*.rb", __FILE__) do |c|
-        Rails.application.config.cache_classes ? require(c) : load(c)
-      end
-      
-    end
-
+    config.to_prepare {}
   end
 end

--- a/lib/spree_redirects/redirect_middleware.rb
+++ b/lib/spree_redirects/redirect_middleware.rb
@@ -6,23 +6,25 @@ module SpreeRedirects
     end
    
     def call(env)
+      # when consider_all_requests_local is false, an exception is raised for 404
+      # consider_all_requests_local should be false in a production environment
+
       begin
-        # when consider_all_requests_local is false, an exception is raised for 404
         status, headers, body = @app.call(env)
-      rescue ActionController::RoutingError => e
+      rescue Exception => e
         routing_error = e
       end
 
-      if (routing_error.present? or status == 404)
+      if routing_error.present? or status == 404
         path = [ env["PATH_INFO"], env["QUERY_STRING"] ].join("?").sub(/[\/\?\s]*$/, "").strip
 
         if url = find_redirect(path)
           # Issue a "Moved permanently" response with the redirect location
           return [ 301, { "Location" => url }, [ "Redirecting..." ] ]
         end
-      else
-        raise routing_error unless Rails.configuration.consider_all_requests_local
       end
+
+      raise routing_error if routing_error.present?
 
       [ status, headers, body ]
     end


### PR DESCRIPTION
- Speed improvement (path is not calculated unless the request is 404)
- Extension works when `consider_all_requests_local = false` (this is default for production)
- Allow redirects to '/'

The main change here is that the extension works when `consider_all_requests_local = false`. This is the default production setting in my rails app (3.2.x); not sure if this was a recent change or not.
